### PR TITLE
backup font support

### DIFF
--- a/LibMediaProvider-1.0.lua
+++ b/LibMediaProvider-1.0.lua
@@ -58,16 +58,16 @@ LMP.DefaultMedia.border = "ESO Gold"
 
 -- FONT
 LMP.MediaTable.font = LMP.MediaTable.font or {}
-LMP.MediaTable.font["ProseAntique"]				= "EsoUI/Common/Fonts/ProseAntiquePSMT.otf"
-LMP.MediaTable.font["Consolas"]					= "EsoUI/Common/Fonts/consola.ttf"
-LMP.MediaTable.font["Futura Condensed"]			= "EsoUI/Common/Fonts/FTN57.otf"
-LMP.MediaTable.font["Futura Condensed Bold"]	= "EsoUI/Common/Fonts/FTN87.otf"
-LMP.MediaTable.font["Futura Condensed Light"]	= "EsoUI/Common/Fonts/FTN47.otf"
-LMP.MediaTable.font["Skyrim Handwritten"]		= "EsoUI/Common/Fonts/Handwritten_Bold.otf"
-LMP.MediaTable.font["Trajan Pro"]				= "EsoUI/Common/Fonts/trajanpro-regular.otf"
-LMP.MediaTable.font["Univers 55"]				= "EsoUI/Common/Fonts/univers55.otf"
-LMP.MediaTable.font["Univers 57"]				= "EsoUI/Common/Fonts/univers57.otf"
-LMP.MediaTable.font["Univers 67"]				= "EsoUI/Common/Fonts/univers67.otf"
+LMP.MediaTable.font["ProseAntique"]				= "$(PROSE_ANTIQUE_FONT)"		-- "EsoUI/Common/Fonts/ProseAntiquePSMT.otf"
+LMP.MediaTable.font["Consolas"]					= "$(CONSOLAS_FONT)"			-- "EsoUI/Common/Fonts/consola.ttf"
+LMP.MediaTable.font["Futura Condensed"]			= "$(FTN57_FONT)"				-- "EsoUI/Common/Fonts/FTN57.otf"
+LMP.MediaTable.font["Futura Condensed Bold"]	= "$(FTN87_FONT)"				-- "EsoUI/Common/Fonts/FTN87.otf"
+LMP.MediaTable.font["Futura Condensed Light"]	= "$(FTN47_FONT)"				-- "EsoUI/Common/Fonts/FTN47.otf"
+LMP.MediaTable.font["Skyrim Handwritten"]		= "$(HANDWRITTEN_BOLD_FONT)"	-- "EsoUI/Common/Fonts/Handwritten_Bold.otf"
+LMP.MediaTable.font["Trajan Pro"]				= "$(TRAJAN_PRO_R_FONT)"		-- "EsoUI/Common/Fonts/trajanpro-regular.otf"
+LMP.MediaTable.font["Univers 55"]				= "$(UNIVERS55_FONT)"			-- "EsoUI/Common/Fonts/univers55.otf"
+LMP.MediaTable.font["Univers 57"]				= "$(UNIVERS57_FONT)"			-- "EsoUI/Common/Fonts/univers57.otf"
+LMP.MediaTable.font["Univers 67"]				= "$(UNIVERS67_FONT)"			-- "EsoUI/Common/Fonts/univers67.otf"
 LMP.DefaultMedia.font = "Univers 55"
 
 -- STATUSBAR

--- a/LibMediaProvider-1.0.txt
+++ b/LibMediaProvider-1.0.txt
@@ -13,4 +13,6 @@
 #
 # You can read the full terms at https://account.elderscrollsonline.com/add-on-terms
 
+fontstrings.xml
+backupfont_$(language).xml
 LibMediaProvider-1.0.lua

--- a/backupfont_jp.xml
+++ b/backupfont_jp.xml
@@ -1,0 +1,28 @@
+<GuiXml>
+    <!-- Optional backup font settings for Japanese language mode. -->
+    <!-- These backup fonts will be used in place of the missing glyphs in the original font -->
+    <BackupFont originalFont="$(PROSE_ANTIQUE_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+    <BackupFont originalFont="$(PROSE_ANTIQUE_FONT)" backupFont="EsoUI/Common/Fonts/ProseAntiquePSMTCyrillic.otf"/>
+
+    <BackupFont originalFont="$(CONSOLAS_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN47_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN57_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN87_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(HANDWRITTEN_BOLD_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+    <BackupFont originalFont="$(HANDWRITTEN_BOLD_FONT)" backupFont="EsoUI/Common/Fonts/HandwrittenCyrillic_Bold.ttf"/>
+
+    <BackupFont originalFont="$(TRAJAN_PRO_R_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+    <BackupFont originalFont="$(TRAJAN_PRO_R_FONT)" backupFont="EsoUI/Common/Fonts/TrajanProCyrillic-Regular.otf"/>
+
+    <BackupFont originalFont="$(UNIVERS55_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(UNIVERS57_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWUDC_70-M.ttf"/>
+    <BackupFont originalFont="$(UNIVERS57_FONT)" backupFont="EsoUI/Common/Fonts/Univers57Cyrillic-Condensed.otf"/>
+
+    <BackupFont originalFont="$(UNIVERS67_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+    <BackupFont originalFont="$(UNIVERS67_FONT)" backupFont="EsoUI/Common/Fonts/Univers67Cyrillic-CondensedBold.otf"/>
+</GuiXml>

--- a/backupfont_ru.xml
+++ b/backupfont_ru.xml
@@ -1,0 +1,28 @@
+<GuiXml>
+    <!-- Optional backup font settings for Russian language mode. -->
+    <!-- These backup fonts will be used in place of the missing glyphs in the original font -->
+    <BackupFont originalFont="$(PROSE_ANTIQUE_FONT)" backupFont="EsoUI/Common/Fonts/ProseAntiquePSMTCyrillic.otf"/>
+    <BackupFont originalFont="$(PROSE_ANTIQUE_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+
+    <BackupFont originalFont="$(CONSOLAS_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN47_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN57_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(FTN87_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(HANDWRITTEN_BOLD_FONT)" backupFont="EsoUI/Common/Fonts/HandwrittenCyrillic_Bold.ttf"/>
+    <BackupFont originalFont="$(HANDWRITTEN_BOLD_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+
+    <BackupFont originalFont="$(TRAJAN_PRO_R_FONT)" backupFont="EsoUI/Common/Fonts/TrajanProCyrillic-Regular.otf"/>
+    <BackupFont originalFont="$(TRAJAN_PRO_R_FONT)" backupFont="EsoUI/Common/Fonts/ESO_KafuPenji-M.ttf"/>
+
+    <BackupFont originalFont="$(UNIVERS55_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+
+    <BackupFont originalFont="$(UNIVERS57_FONT)" backupFont="EsoUI/Common/Fonts/Univers57Cyrillic-Condensed.otf"/>
+    <BackupFont originalFont="$(UNIVERS57_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWUDC_70-M.ttf"/>
+
+    <BackupFont originalFont="$(UNIVERS67_FONT)" backupFont="EsoUI/Common/Fonts/Univers67Cyrillic-CondensedBold.otf"/>
+    <BackupFont originalFont="$(UNIVERS67_FONT)" backupFont="EsoUI/Common/Fonts/ESO_FWNTLGUDC70-DB.ttf"/>
+</GuiXml>

--- a/fontstrings.xml
+++ b/fontstrings.xml
@@ -1,0 +1,13 @@
+<GuiXml>
+    <!-- common font string defintions for all language modes. -->
+    <String name="PROSE_ANTIQUE_FONT" value="EsoUI/Common/Fonts/ProseAntiquePSMT.otf" />
+    <String name="CONSOLAS_FONT" value="EsoUI/Common/Fonts/consola.ttf" />
+    <String name="FTN47_FONT" value="EsoUI/Common/Fonts/FTN47.otf" />
+    <String name="FTN57_FONT" value="EsoUI/Common/Fonts/FTN57.otf" />
+    <String name="FTN87_FONT" value="EsoUI/Common/Fonts/FTN87.otf" />
+    <String name="HANDWRITTEN_BOLD_FONT" value="EsoUI/Common/Fonts/Handwritten_Bold.otf" />
+    <String name="TRAJAN_PRO_R_FONT" value="EsoUI/Common/Fonts/TrajanPro-Regular.otf" />
+    <String name="UNIVERS55_FONT" value="EsoUI/Common/Fonts/Univers55.otf" />
+    <String name="UNIVERS57_FONT" value="EsoUI/Common/Fonts/Univers57.otf" />
+    <String name="UNIVERS67_FONT" value="EsoUI/Common/Fonts/Univers67.otf" />
+</GuiXml>


### PR DESCRIPTION
# Modification Details: 
- changed font media table.
- added font strings file for ESO embedded western fonts.
- added optional xml files to define the backup font.

# Purpose of Change
Unfortunately, the behavior of fallback fonts has changed since update 25, and the default fallback font is gone.
At least if you specify a font filename with SetFont method, the fallback font feature doesn't seem to work properly.

As a result, fetching and using the registered fonts of LibMediaProvider, there is an issue that Japanese Kanji characters could not be displayed in Japanese mode.

This is a niche issue, but I wanted to solve it so that it would not affect users who only use Western fonts.

I have confirmed this patch improves the behavior of add-ons that utilize this library, such as pchat and Srendarr, in Japanese language mode.